### PR TITLE
fixate puppetteer version

### DIFF
--- a/steps/funneldrop_fixing_bug_pr.yml
+++ b/steps/funneldrop_fixing_bug_pr.yml
@@ -15,7 +15,7 @@ githubActions:
   frontend:
     capabilities:
     - jest-puppeteer
-    - puppeteer
+    - "puppeteer@18.1.0"
     testFile: "profile.test.js"
 trigger:
   type: github_pr_lifecycle_status


### PR DESCRIPTION
This fixes the following error some users got (and myself as well): 
`Cannot find module 'puppeteer-core/internal/common/Device.js' from '../node_modules/puppeteer/lib/cjs/puppeteer/puppeteer.js'`


Solution is based on: https://stackoverflow.com/questions/74078944/cannot-find-module-puppeteer-core-internal-common-device-js