### PR TITLE
Only use jest-puppeteer

### DIFF
--- a/steps/funneldrop_fixing_bug_pr.yml
+++ b/steps/funneldrop_fixing_bug_pr.yml
@@ -16,7 +16,6 @@ githubActions:
   frontend:
     capabilities:
     - jest-puppeteer
-    - "puppeteer@18.1.0"
     testFile: "profile.test.js"
 trigger:
   type: github_pr_lifecycle_status


### PR DESCRIPTION
We don't need to add both now, since it's been added as a capability.